### PR TITLE
feat: Added key derivation

### DIFF
--- a/src/drive/lib/encryption.js
+++ b/src/drive/lib/encryption.js
@@ -53,10 +53,8 @@ export const deriveKey = async (password, salt) => {
   const preKey = await slowHashing(passwordAsKey, saltBuffer, {
     iterations: 1000
   })
-  const key = await asDerivableKey(preKey).then(key => {
-    return slowHashing(key, passwordBuffer, { iterations: 1 })
-  })
-  return key
+  const key = await asDerivableKey(preKey)
+  return slowHashing(key, passwordBuffer, { iterations: 1 })
 }
 
 export const exportKey = async (key, vaultKey) => {

--- a/src/drive/lib/encryption.js
+++ b/src/drive/lib/encryption.js
@@ -13,7 +13,7 @@ const asDerivableKey = async (
   } else {
     usableMaterial = stringToArrayBuffer(baseMaterial)
   }
-  return await window.crypto.subtle.importKey(
+  return window.crypto.subtle.importKey(
     'raw',
     usableMaterial,
     { name: keyDerivationAlgorithm },


### PR DESCRIPTION
Added the key derivation function and other subfunctions
- `asDerivableKey`: trick proposed in order to be able to re-use a derived Key into another derivation
- `slowHashing`: wrapper around `deriveKey` with a default PBKDF2 behaviour
- `deriveKey`: implementation of the method proposed in [our paper](https://paper.dropbox.com/doc/Notes-techniques-sur-le-chiffrement-E2E-Cozy--AeYerFwmCQ_FU0LVreL6_g0KAg-wownX6RBaRC2XZE22vPDs#:h2=D%C3%A9rivation-de-clef) to derive a strong key
- `importKey` and `exportKey`: wrappers around subtleCrypto's `wrap` and `unwrap`