### PR TITLE
refactor: Encryption module

### DIFF
--- a/src/drive/store/rootReducer.js
+++ b/src/drive/store/rootReducer.js
@@ -18,6 +18,7 @@ import {
   UNLINK
 } from 'drive/mobile/modules/authorization/duck'
 import { default as replication } from 'drive/mobile/modules/replication/duck'
+import { default as encryption } from 'drive/web/modules/encryption/duck'
 
 // Per Dan Abramov: https://stackoverflow.com/questions/35622588/how-to-reset-the-state-of-a-redux-store/35641992#35641992
 const createRootReducer = client => {
@@ -28,7 +29,8 @@ const createRootReducer = client => {
     upload,
     selection,
     rename,
-    availableOffline
+    availableOffline,
+    encryption
   }
 
   const mobileReducer = combineReducers({

--- a/src/drive/web/modules/encryption/Passphrase.jsx
+++ b/src/drive/web/modules/encryption/Passphrase.jsx
@@ -6,11 +6,8 @@ import Alerter from 'cozy-ui/react/Alerter'
 import { translate } from 'cozy-ui/react/I18n'
 import { withClient } from 'cozy-client'
 import { Input } from 'cozy-ui/react'
-import { DERIVED_PASSPHRASE_KEY_ID } from 'drive/lib/encryption/keys'
-import {
-  decryptVaultEncryptionKey,
-  createVaultEncryptionKey
-} from 'drive/web/modules/navigation/duck'
+import { DERIVED_PASSPHRASE_KEY_ID } from './keys'
+import { decryptVaultEncryptionKey, createVaultEncryptionKey } from './duck'
 
 class Passphrase extends Component {
   constructor(props) {

--- a/src/drive/web/modules/encryption/data.js
+++ b/src/drive/web/modules/encryption/data.js
@@ -1,7 +1,7 @@
 /* global cozy */
 
 import { decode as decodeArrayBuffer } from 'base64-arraybuffer'
-import { importKeyJwk } from './keys'
+import { importKey } from './keys'
 
 /**
   Encrypt data with the given key
@@ -41,7 +41,8 @@ export const createDecryptedFileURL = async file => {
   // prepare decryption
   const encryption = file.metadata.encryption
   const iv = decodeArrayBuffer(encryption.iv)
-  const key = await importKeyJwk(encryption.key)
+  // TODO the key should be encrypted
+  const key = await importKey('jwk', encryption.key)
   // Now fetch data
   const resp = await cozy.client.files.downloadById(file.id || file._id)
   const encBuff = await resp.arrayBuffer()

--- a/src/drive/web/modules/encryption/duck.js
+++ b/src/drive/web/modules/encryption/duck.js
@@ -1,0 +1,91 @@
+import {
+  deriveKey,
+  generateAESKey,
+  wrapAESKey,
+  unwrapAESKey,
+  exportKey,
+  importKey,
+  DERIVED_PASSPHRASE_KEY_ID
+} from './keys'
+import { decode as decodeArrayBuffer } from 'base64-arraybuffer'
+import Alerter from 'cozy-ui/react/Alerter'
+
+export const DECRYPT_VAULT_ENCRYPTION_KEY = 'DECRYPT_ENCRYPTION_KEY'
+export const CREATE_VAULT_ENCRYPTION_KEY = 'CREATE_ENCRYPTION_KEY'
+
+// reducer
+const encryption = (state = null, action) => {
+  switch (action.type) {
+    case DECRYPT_VAULT_ENCRYPTION_KEY:
+    case CREATE_VAULT_ENCRYPTION_KEY:
+      return action.key
+    default:
+      return state
+  }
+}
+
+// actions
+export const decryptVaultEncryptionKey = (vault, passphrase) => {
+  return async (dispatch, _, { client }) => {
+    const salt = client.getStackClient().uri
+    const derivedKey = await deriveKey(passphrase, salt)
+    const wrappedKey = decodeArrayBuffer(vault.key.encrypted_key)
+    // WARNING the vault key is AES-KW. However, due to a bug in Mozilla,
+    // we are forced to ask for a AES-GCM key, and then "convert" it in AES-KW
+    const vaultKey = await unwrapAESKey(wrappedKey, derivedKey, {
+      algorithm: 'AES-GCM',
+      keyUsages: vault.key.key_ops
+    }).catch(error => {
+      Alerter.error('encryption.passphrase.incorrect')
+      throw error
+    })
+    const exportVaultKey = await exportKey('raw', vaultKey)
+    const importVaultKey = await importKey('raw', exportVaultKey, {
+      algorithm: 'AES-KW',
+      keyUsages: ['wrapKey', 'unwrapKey']
+    })
+    return dispatch({
+      type: DECRYPT_VAULT_ENCRYPTION_KEY,
+      key: importVaultKey
+    })
+  }
+}
+
+export const createVaultEncryptionKey = passphrase => {
+  return async (dispatch, _, { client }) => {
+    // Derive secret key
+    const stackClient = client.getStackClient()
+    const salt = stackClient.uri
+    const derivedKey = await deriveKey(passphrase, salt)
+
+    // Generate vault key and wrap it
+    const vaultKey = await generateAESKey({
+      algorithm: 'AES-KW',
+      keyUsages: ['wrapKey', 'unwrapKey']
+    })
+    const wrapped = await wrapAESKey(
+      vaultKey,
+      derivedKey,
+      DERIVED_PASSPHRASE_KEY_ID
+    )
+    // Save the wrapped key in settings
+    const settings = await client.query(
+      client.find('io.cozy.settings').getById('io.cozy.settings.instance')
+    )
+    const keys =
+      settings.data.encryption && settings.data.encryption.keys
+        ? [...settings.data.encryption.keys, wrapped]
+        : [wrapped]
+    const encryption = { ...settings.data.encryption, keys }
+    const newSettings = { ...settings.data, encryption }
+
+    await client.collection('io.cozy.settings').update(newSettings)
+
+    return dispatch({
+      type: CREATE_VAULT_ENCRYPTION_KEY,
+      key: vaultKey
+    })
+  }
+}
+
+export default encryption

--- a/src/drive/web/modules/encryption/keys.js
+++ b/src/drive/web/modules/encryption/keys.js
@@ -9,18 +9,21 @@ export const encodeData = data => {
   return encoder.encode(data)
 }
 
-// TODO: remove this in the future (use wrapKey)
-export const exportKeyJwk = async key => {
-  return window.crypto.subtle.exportKey('jwk', key)
+export const exportKey = async (format, key) => {
+  return window.crypto.subtle.exportKey(format, key)
 }
 
-export const importKeyJwk = async (keyJWK, { algorithm, length } = {}) => {
+export const importKey = async (
+  format,
+  keyJWK,
+  { algorithm, length, keyUsages } = {}
+) => {
   return window.crypto.subtle.importKey(
-    'jwk',
+    format,
     keyJWK,
     { name: algorithm || 'AES-GCM', length: length || 256 },
     true,
-    ['encrypt', 'decrypt']
+    keyUsages || ['encrypt', 'decrypt']
   )
 }
 

--- a/src/drive/web/modules/navigation/FileExplorer.jsx
+++ b/src/drive/web/modules/navigation/FileExplorer.jsx
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router'
 import { translate } from 'cozy-ui/react/I18n'
 import SharingProvider from 'sharing'
 import { showModal } from 'react-cozy-helpers'
-import Passphrase from 'drive/web/modules/drive/Passphrase'
+import Passphrase from 'drive/web/modules/encryption/Passphrase'
 import { VAULT_DIR_ID } from 'drive/constants/config'
 
 import RealtimeFiles from './RealtimeFiles'

--- a/src/drive/web/modules/navigation/duck/index.js
+++ b/src/drive/web/modules/navigation/duck/index.js
@@ -26,7 +26,5 @@ export {
   trashFiles,
   downloadFiles,
   exportFilesNative,
-  openFileWith,
-  decryptVaultEncryptionKey,
-  createVaultEncryptionKey
+  openFileWith
 } from './actions'

--- a/src/drive/web/modules/navigation/duck/reducer.js
+++ b/src/drive/web/modules/navigation/duck/reducer.js
@@ -19,9 +19,7 @@ import {
   CREATE_FOLDER_SUCCESS,
   ADD_FILE,
   UPDATE_FILE,
-  DELETE_FILE,
-  DECRYPT_VAULT_ENCRYPTION_KEY,
-  CREATE_VAULT_ENCRYPTION_KEY
+  DELETE_FILE
 } from './actions'
 
 import {
@@ -275,17 +273,6 @@ const lastFetch = (state = null, action) => {
   }
 }
 
-// reducer for encryption
-const encryption = (state = null, action) => {
-  switch (action.type) {
-    case DECRYPT_VAULT_ENCRYPTION_KEY:
-    case CREATE_VAULT_ENCRYPTION_KEY:
-      return action.key
-    default:
-      return state
-  }
-}
-
 const deduplicateCreateDeleteActions = originalReducer => {
   const created = []
   const deleted = []
@@ -348,8 +335,7 @@ export default combineReducers({
   sort,
   files,
   fetchStatus,
-  lastFetch,
-  encryption
+  lastFetch
 })
 
 // TODO: temp

--- a/src/drive/web/modules/upload/index.js
+++ b/src/drive/web/modules/upload/index.js
@@ -5,8 +5,8 @@ import { hasSharedParent, isShared } from 'sharing/state'
 import { CozyFile } from 'models'
 import UploadQueue from './UploadQueue'
 import { VAULT_DIR_ID } from 'drive/constants/config'
-import { generateAESKey, exportKeyJwk } from 'drive/lib/encryption/keys'
-import { encryptData } from 'drive/lib/encryption/data'
+import { generateAESKey, exportKey } from 'drive/web//modules/encryption/keys'
+import { encryptData } from 'drive/web/modules/encryption/data'
 import { encode as encodeArrayBuffer } from 'base64-arraybuffer'
 
 export { UploadQueue }
@@ -200,7 +200,7 @@ const uploadFile = async (client, file, dirID) => {
       // Encrypt the file with a newly generated AES key
       const aesKey = await generateAESKey()
       const encrypted = await encryptData(aesKey, data)
-      const jwk = await exportKeyJwk(aesKey)
+      const jwk = await exportKey('jwk', aesKey)
 
       // Create the metadata object containing the encryption info
       // TODO encrypt the key with exportKey

--- a/src/drive/web/modules/viewer/NoViewerButton.jsx
+++ b/src/drive/web/modules/viewer/NoViewerButton.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import { Button, Alerter } from 'cozy-ui/transpiled/react'
 import { logException } from 'drive/lib/reporter'
 import { isMobileApp } from 'cozy-device-helper'
-import { createDecryptedFileURL } from 'drive/lib/encryption/data'
+import { createDecryptedFileURL } from 'drive/web/modules/encryption/data'
 import { openLocalFileCopy } from 'drive/mobile/modules/offline/duck'
 
 class AsyncActionButton extends React.Component {


### PR DESCRIPTION
The whole encryption code is moved in web/modules/encryption:
* This allows to group everything liked to encryption in one place (lib, components, actions...)
* We can make a dedicated redux store through duck.js and therefore access the vault key with `state.encryption` (instead of `state.view.encryption` before).